### PR TITLE
feat: add lab12-1 iio subsystem example code

### DIFF
--- a/lab12-1-iio-subsystem-proximity/Makefile
+++ b/lab12-1-iio-subsystem-proximity/Makefile
@@ -1,0 +1,16 @@
+PWD := $(shell pwd)
+KVERSION := $(shell uname -r)
+KERNEL_DIR := /lib/modules/$(shell uname -r)/build
+
+MODULE_NAME = iio-constant
+obj-m += $(MODULE_NAME).o
+
+all: dtb
+	make -C $(KERNEL_DIR) M=$(PWD) modules
+
+dtb:
+	dtc -@ -I dts -O dtb -o $(MODULE_NAME).dtbo $(MODULE_NAME).dts
+
+clean:
+	make -C $(KERNEL_DIR) M=$(PWD) clean
+	rm $(MODULE_NAME).dtbo

--- a/lab12-1-iio-subsystem-proximity/Readme.md
+++ b/lab12-1-iio-subsystem-proximity/Readme.md
@@ -1,0 +1,53 @@
+
+# Put Device Tree on device with overlay
+## Compile Deveice Tree Blob
+```
+dtc -@ -I dts -O dtb -o <BLOB_NAME>.dtbo <FILE_NAME>.dts
+```
+
+## Put Blob in `/boot` directory
+```
+cp <BLOB_NAME>.dtbo /boot/overlays/
+```
+
+## Modify Boot Configuration
+```
+vi /boot/config.txt
+---
++dtoverlay=arduino-pinctrl #arduino-pinctrl is device tree node
+```
+
+## Check Device Tree on Device
+```
+dtc -I fs /proc/device-tree -O dts
+```
+
+# Load IIO Module
+## Load IIO Dependency Module
+```
+sudo modprobe industrialio-triggered-buffer
+```
+## Load iio-constant Module
+```
+sudo insmod iio-constant.ko
+```
+
+# Observation
+## sysfs
+```
+ls /sys/bus/iio/devices/iio\:device1
+---
+in_proximity0_input  in_proximity1_input  in_proximity2_input  in_proximity3_input  in_proximity4_input  in_proximity5_input  name  of_node  power  subsystem  uevent
+```
+
+## Show Values
+```
+cat in_proximity{0..5}_input
+---
+9876
+9876.001234
+9876.001234 dB
+9876 1234 
+8.003241491
+0.000000000
+```

--- a/lab12-1-iio-subsystem-proximity/iio-constant.c
+++ b/lab12-1-iio-subsystem-proximity/iio-constant.c
@@ -1,0 +1,89 @@
+#include <linux/kernel.h>
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/platform_device.h>
+#include <linux/gpio/consumer.h>
+#include <linux/iio/consumer.h>
+#include <linux/iio/iio.h>
+#include <linux/of.h>
+
+#define IIO_CHANNEL_DEFINE(num)   {\
+    .type = IIO_PROXIMITY,\
+    .indexed = 1,\
+    .channel = (num),\
+    .info_mask_separate = BIT(IIO_CHAN_INFO_PROCESSED),\
+  }\
+
+static const struct iio_chan_spec constant_iio_channels[] = {
+  IIO_CHANNEL_DEFINE(0),
+  IIO_CHANNEL_DEFINE(1),
+  IIO_CHANNEL_DEFINE(2),
+  IIO_CHANNEL_DEFINE(3),
+  IIO_CHANNEL_DEFINE(4),
+  IIO_CHANNEL_DEFINE(5),
+};
+
+static int constant_iio_read_raw(struct iio_dev *iio,
+                                  struct iio_chan_spec const *chan,
+                                  int *val0, int *val1, long mask)
+{
+  *val0 = 9876;
+  *val1 = 1234;
+  switch (chan->channel)
+  {
+    case 0:
+      return IIO_VAL_INT;
+    case 1:
+      return IIO_VAL_INT_PLUS_MICRO;
+    case 2:
+      return IIO_VAL_INT_PLUS_MICRO_DB;
+    case 3:
+      return IIO_VAL_INT_MULTIPLE;
+    case 4:
+      return IIO_VAL_FRACTIONAL;
+    case 5:
+      return IIO_VAL_FRACTIONAL_LOG2;
+    default:
+      return 0;
+  }
+}
+
+struct iio_info constant_iio_info = {
+  .read_raw = constant_iio_read_raw,
+};
+
+static int constant_iio_probe(struct platform_device *pdev)
+{
+  struct device *dev = &pdev->dev;
+  struct iio_dev *iio;
+
+  dev_info(dev, "probing");
+
+  iio = devm_iio_device_alloc(dev, 0);
+  if (IS_ERR(iio)) {
+    dev_err(dev, "failed to allocate iio device");
+    return PTR_ERR(iio);
+  }
+  iio->name = pdev->name;
+  iio->info = &constant_iio_info;
+  iio->modes = INDIO_DIRECT_MODE;
+  iio->channels = constant_iio_channels;
+  iio->num_channels = ARRAY_SIZE(constant_iio_channels);
+
+  return devm_iio_device_register(dev, iio);
+}
+
+static const struct of_device_id constant_iio_ids[] = {
+  {.compatible = "iio,constant",},
+  {}
+};
+static struct platform_driver constant_iio_driver = {
+  .driver = {
+    .name = KBUILD_MODNAME,
+    .of_match_table = constant_iio_ids,
+  },
+  .probe = constant_iio_probe
+};
+
+MODULE_LICENSE("GPL");
+module_platform_driver(constant_iio_driver);

--- a/lab12-1-iio-subsystem-proximity/iio-constant.dts
+++ b/lab12-1-iio-subsystem-proximity/iio-constant.dts
@@ -1,0 +1,12 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+  compatible = "brcm,bcm2835";
+};
+&{/} {
+  iio_constant: iio_constant {
+    compatible = "iio,constant";
+    status = "okay";
+  };
+};


### PR DESCRIPTION
# Test

## Raspberry Pi 4
```
root@raspberrypi:/home/yimu/modules/Raspberry-Pi-Kernel-Module/lab12-1-iio-subsystem-proximity# lsmod | grep iio
\iio_constant           16384  0
industrialio           81920  4 iio_constant,dht11,industrialio_triggered_buffer,kfifo_buf
root@raspberrypi:/home/yimu/modules/Raspberry-Pi-Kernel-Module/lab12-1-iio-subsystem-proximity# ls /sys/bus/iio/devices/iio\:device
ls: cannot access '/sys/bus/iio/devices/iio:device': No such file or directory
root@raspberrypi:/home/yimu/modules/Raspberry-Pi-Kernel-Module/lab12-1-iio-subsystem-proximity# ls /sys/bus/iio/devices/iio\:device
iio:device0/ iio:device1/ 
root@raspberrypi:/home/yimu/modules/Raspberry-Pi-Kernel-Module/lab12-1-iio-subsystem-proximity# ls /sys/bus/iio/devices/iio\:device1/
in_proximity0_input  in_proximity1_input  in_proximity2_input  in_proximity3_input  in_proximity4_input  in_proximity5_input  name  of_node  power  subsystem  uevent
root@raspberrypi:/home/yimu/modules/Raspberry-Pi-Kernel-Module/lab12-1-iio-subsystem-proximity# cd /sys/bus/iio/devices/iio\:device1/
root@raspberrypi:/sys/bus/iio/devices/iio:device1# cat in_proximity{0..5}_input
9876
9876.001234
9876.001234 dB
9876 1234 
8.003241491
0.000000000
```
